### PR TITLE
allow to set different max date when fetching tiles

### DIFF
--- a/glad/check_glad_tiles.py
+++ b/glad/check_glad_tiles.py
@@ -25,7 +25,9 @@ def main():
     kwargs: Dict[str, Any] = {"years": args.years, "num_tiles": num_tiles}
 
     try:
-        kwargs["tile_date"], tile_ids = get_most_recent_day(tile_ids=tile_ids, **kwargs)
+        kwargs["tile_date"], tile_ids = get_most_recent_day(
+            max_date=args.max_date, tile_ids=tile_ids, **kwargs
+        )
     except ValueError:
         logging.warning("Cannot find recently processes tiles.")
 

--- a/glad/glad_pipeline.py
+++ b/glad/glad_pipeline.py
@@ -85,9 +85,9 @@ def main():
     }
 
     try:
-        # TODO
-        #  add some logic to skip this step in case we don't deal with current years
-        kwargs["tile_date"], tile_ids = get_most_recent_day(tile_ids=tile_ids, **kwargs)
+        kwargs["tile_date"], tile_ids = get_most_recent_day(
+            max_date=args.max_date, tile_ids=tile_ids, **kwargs
+        )
     except ValueError:
         logging.error("Cannot find recently processes tiles. Aborting")
         slack_webhook(

--- a/glad/stages/collectors.py
+++ b/glad/stages/collectors.py
@@ -17,11 +17,11 @@ def get_most_recent_day(**kwargs: Any) -> Tuple[str, List[str]]:
     tile_ids: List[str] = kwargs["tile_ids"]
     years: List[int] = kwargs["years"]
     num_tiles: int = kwargs["num_tiles"]
-    today: datetime.datetime = datetime.datetime.today()
+    max_date: datetime.datetime = kwargs["max_date"]
 
     # check for most recent day of GLAD data
     for day_offset in range(0, 11):
-        process_date: str = (today - datetime.timedelta(days=day_offset)).strftime(
+        process_date: str = (max_date - datetime.timedelta(days=day_offset)).strftime(
             "%Y/%m_%d"
         )
 

--- a/glad/utils/parser.py
+++ b/glad/utils/parser.py
@@ -91,6 +91,12 @@ def get_parser():
         default=115,
         help="Number of expected input tiles",
     )
+    parser.add_argument(
+        "--max_date",
+        type=lambda s: datetime.strptime(s, "%Y-%m-%d"),
+        default=datetime.today(),
+        help="Max date to use when fetching new tiles",
+    )
 
     return parser.parse_args()
 


### PR DESCRIPTION
Signed-off-by: Thomas Maschler <tmaschler@wri.org>

<!-- Please refer to our contributing documentation for any questions on submitting a pull request, or let us know here if you need any help -->

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [x] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [x] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 

<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please check the type of change your PR introduces:
- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number:
- Pipeline always download the most recent tile set, cannot pick an earlier date


## What is the new behavior?
<!-- Please describe the behavior or changes that are being added by this PR. -->

- allow to set max date as cmd line args to force script to download earlier dates


## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this introduces a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information

<!-- Any other information that is important to this PR such as screenshots of how the component looks before and after the change. -->
