### PR TITLE
Delete future alerts

### DIFF
--- a/glad/pipes.py
+++ b/glad/pipes.py
@@ -8,6 +8,7 @@ from glad.stages.download import (
     download_stats_db,
 )
 from glad.stages.change_pixel_depth import change_pixel_depth
+from glad.stages.validate import validate_tiles
 from glad.stages.encode_glad import (
     encode_date_conf,
     prep_intensity,
@@ -124,6 +125,7 @@ def date_conf_pipe(tile_ids, **kwargs):
     pipe = (
         tile_ids
         | Stage(download_latest_tiles, name="download", **kwargs).setup(workers=workers)
+        | Stage(validate_tiles, name="validate_tiles", **kwargs).setup(workers=workers)
         | Stage(change_pixel_depth, name="pixel_depth", **kwargs).setup(workers=workers)
         | Stage(upload_raw_tile_s3, name="pixel_depth", **kwargs).setup(workers=workers)
         | Stage(encode_date_conf, name="encode_day_conf", **kwargs).setup(

--- a/glad/stages/tile_db.py
+++ b/glad/stages/tile_db.py
@@ -2,6 +2,7 @@ import pandas as pd
 import sqlite3
 import logging
 import glob
+from datetime import datetime
 
 
 def delete_current_years(**kwargs):
@@ -26,6 +27,13 @@ def delete_current_years(**kwargs):
             "WHERE alert_date >= '{1}-01-01' "
             "AND alert_date <= '{1}-12-31';".format(db_table, year)
         )
+
+    logging.info("Delete any future entries, if they exist")
+    today = datetime.now().strftime("%Y-%m-%d")
+    cursor.execute(
+        "DELETE FROM {0} "
+        "WHERE alert_date > '{1}';".format(db_table, today)
+    )
 
     conn.commit()
     conn.close()

--- a/glad/stages/validate.py
+++ b/glad/stages/validate.py
@@ -7,11 +7,9 @@ def validate_tiles(tiles, **kwargs):
         f_name, year, folder, tile_id = file_details(tile)
 
         if f_name == "day.tif":
-            expected_min = 0
-            expected_max = 366
+            expected_range = range(0, 367)
         else:
-            expected_min = 0
-            expected_max = 3
+            expected_range = [0, 2, 3]
 
         gtif = gdal.Open(tile)
         srcband = gtif.GetRasterBand(1)
@@ -20,8 +18,8 @@ def validate_tiles(tiles, **kwargs):
         min = stats[0]
         max = stats[1]
 
-        if min < expected_min or max > expected_max:
-            raise ValueError(f"Tile f{tile_id} in year {year} had min, max of {min, max}, "
-                             f"but expected min, max of {expected_min, expected_max}")
+        if min not in expected_range or max not in expected_range:
+            raise ValueError(f"Tile f{tile_id}, year {year}, file {f_name} "
+                             f"had min, max of {min, max}, which is outside of the expected range")
 
         yield tile

--- a/glad/stages/validate.py
+++ b/glad/stages/validate.py
@@ -1,0 +1,25 @@
+from glad.utils.utils import file_details
+from osgeo import gdal
+
+
+def validate_tiles(tiles, **kwargs):
+    for tile in tiles:
+        f_name, year, folder, tile_id = file_details(tile)
+
+        if f_name == "day.tif":
+            expected_min = 0
+            expected_max = 366
+        else:
+            expected_min = 0
+            expected_max = 3
+
+        gtif = gdal.Open(tile)
+        srcband = gtif.GetRasterBand(1)
+        stats = srcband.GetStatistics(True, True)
+
+        min = stats[0]
+        max = stats[1]
+
+        if min < expected_min or max > expected_max:
+            raise ValueError(f"Tile f{tile_id} in year {year} had min, max of {min, max}, "
+                             f"but expected min, max of {expected_min, expected_max}")

--- a/glad/stages/validate.py
+++ b/glad/stages/validate.py
@@ -23,3 +23,5 @@ def validate_tiles(tiles, **kwargs):
         if min < expected_min or max > expected_max:
             raise ValueError(f"Tile f{tile_id} in year {year} had min, max of {min, max}, "
                              f"but expected min, max of {expected_min, expected_max}")
+
+        yield tile


### PR DESCRIPTION
Sometimes GLAD tiles come from UMD corrupted with bad values, and this can cause our encoding process to think alerts are on completely wrong dates, including the future. The future is especially bad, since it will mess up the latest endpoint. 

## Pull request checklist

Please check if your PR fulfills the following requirements:
- [X] Make sure you are requesting to pull a topic/feature/bugfix branch (right side). Don't request your master!
- [X] Make sure you are making a pull request against the develop branch (left side). Also you should start your branch off our develop.
- [X] Check the commit's or even all commits' message styles matches our requested structure.
- [ ] Check your code additions will fail neither code linting checks nor unit test.



## Pull request type

Please check the type of change your PR introduces:
- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] Documentation content changes
- [ ] Other (please describe): 


## What is the current behavior?
Just accepts what GLAD gives, and will generate bad output data if if the input data is wrong;


## What is the new behavior?

- Validate the input tiles have values within the expected limits, otherwise just fail instead of generating bad data and replacing the old files. 
- Delete from stats.db any alert in the future, just to ensure there's nothing lingering around to mess up the latest endpoint.

## Does this introduce a breaking change?

- [ ] Yes
- [X] No

